### PR TITLE
fix: Release 5.0.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           UNSAFE_PYO3_SKIP_VERSION_CHECK: 1
         with:
-          args: --release --out dist
+          args: --release --out dist --interpreter ${{ matrix.python_version }}
           target: x64
       - run: pip install --find-links=./dist jh2
         name: Install built package

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Release History
 ===============
 
+5.0.12 (2026-05-29)
+------------------
+
+- Fixed RFC conformance (7540 6.9.2) mandates that the connection-level flow-control window always starts at 65535 octets,
+  regardless of what SETTINGS_INITIAL_WINDOW_SIZE advertises.
+- Omitted MAX_FRAME_SIZE and ENABLE_CONNECT_PROTOCOL from the default settings
+  preface; both RFC implicit defaults (16384, 0) still apply via property
+  getters.
+- Changed default settings: HEADER_TABLE_SIZE -> 4096 to 65536; INITIAL_WINDOW_SIZE = 65535 to 6291456 and MAX_HEADER_LIST_SIZE = unset to 262144.
+- Fixed HPACK decoder cap not being initialized from local_settings.
+  HEADER_TABLE_SIZE at construction time; Settings.acknowledge() only emits
+  events for changed values, so defaults never propagated and the decoder
+  stayed at 4096, rejecting legitimate header blocks once HEADER_TABLE_SIZE
+  was raised.
+- (rust) Improved HPACK error reporting: replaced generic "operation failed" messages with formatted upstream error variants for diagnosability.
+
 5.0.11 (2026-04-05)
 ------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -41,7 +41,7 @@ checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
 
 [[package]]
 name = "jh2"
-version = "5.0.11"
+version = "5.0.12"
 dependencies = [
  "httlib-hpack",
  "pyo3",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "once_cell"
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "python3-dll-a"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d381ef313ae70b4da5f95f8a4de773c6aa5cd28f73adec4b4a31df70b66780d8"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh2"
-version = "5.0.11"
+version = "5.0.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/jh2/__init__.py
+++ b/jh2/__init__.py
@@ -7,4 +7,4 @@ A HTTP/2 implementation.
 
 from __future__ import annotations
 
-__version__ = "5.0.11"
+__version__ = "5.0.12"

--- a/jh2/connection.py
+++ b/jh2/connection.py
@@ -461,9 +461,29 @@ class H2Connection:
         )
         self.remote_settings = Settings(client=not self.config.client_side)
 
-        # The current value of the connection flow control windows on the
-        # connection.
-        self.outbound_flow_control_window = self.remote_settings.initial_window_size
+        # Propagate the initial (default) local HEADER_TABLE_SIZE to the
+        # decoder's hard limit. Settings that match RFC 7540 defaults are not
+        # surfaced through ``Settings.acknowledge`` (their deque holds a single
+        # entry), so without this the decoder's hard limit would stay at the
+        # codec's construction default (4096) while we advertise something
+        # larger to the peer. The peer's resulting Dynamic Table Size Update
+        # would then be rejected with ``InvalidMaxDynamicSize``.
+        #
+        # The encoder side is deliberately not touched here: its table size is
+        # bounded by what the *remote* advertises, and the RFC default until
+        # the remote sends SETTINGS is 4096. It will be raised on demand from
+        # ``_receive_settings_frame``.
+        self.decoder.max_allowed_table_size = self.local_settings.header_table_size
+
+        # The current value of the connection flow control window for data we
+        # can send to the peer.
+        #
+        # RFC 7540 §6.9.2: ``SETTINGS_INITIAL_WINDOW_SIZE`` does **not**
+        # affect the connection-level flow-control window. The peer's
+        # connection window always starts at 65535 octets regardless of what
+        # they advertise via ``INITIAL_WINDOW_SIZE`` and can only be grown by
+        # them via ``WINDOW_UPDATE`` frames on stream 0.
+        self.outbound_flow_control_window = 65535
 
         #: The maximum size of a frame that can be emitted by this peer, in
         #: bytes.
@@ -492,9 +512,17 @@ class H2Connection:
         self._closed_streams = SizeLimitDict(size_limit=self.MAX_CLOSED_STREAMS)
 
         # The flow control window manager for the connection.
-        self._inbound_flow_control_window_manager = WindowManager(
-            max_window_size=self.local_settings.initial_window_size
-        )
+        #
+        # RFC 7540 6.9.2: ``SETTINGS_INITIAL_WINDOW_SIZE`` does not
+        # affect the connection-level flow-control window. The connection
+        # window always starts at the protocol default of 65535 octets and
+        # can only be grown via ``WINDOW_UPDATE`` frames on stream 0. Using
+        # ``local_settings.initial_window_size`` here desyncs our view from
+        # the peer's, which on a large advertised window causes the
+        # auto-update algorithm to emit oversized increments that the peer
+        # eventually rejects with ``FLOW_CONTROL_ERROR`` ("May not increment
+        # flow control window past 2147483647").
+        self._inbound_flow_control_window_manager = WindowManager(max_window_size=65535)
 
         # When in doubt use dict-dispatch.
         self._frame_dispatch_table = {

--- a/jh2/settings.py
+++ b/jh2/settings.py
@@ -134,11 +134,10 @@ class Settings(MutableMapping):
         #
         # This contains the default values for HTTP/2.
         self._settings = {
-            SettingCodes.HEADER_TABLE_SIZE: collections.deque([4096]),
+            SettingCodes.HEADER_TABLE_SIZE: collections.deque([65536]),
             SettingCodes.ENABLE_PUSH: collections.deque([int(client)]),
-            SettingCodes.INITIAL_WINDOW_SIZE: collections.deque([65535]),
-            SettingCodes.MAX_FRAME_SIZE: collections.deque([16384]),
-            SettingCodes.ENABLE_CONNECT_PROTOCOL: collections.deque([0]),
+            SettingCodes.INITIAL_WINDOW_SIZE: collections.deque([6291456]),
+            SettingCodes.MAX_HEADER_LIST_SIZE: collections.deque([262144]),
         }
         if initial_values is not None:
             for key, value in initial_values.items():
@@ -220,7 +219,8 @@ class Settings(MutableMapping):
         The current value of the :data:`MAX_FRAME_SIZE
         <h2.settings.SettingCodes.MAX_FRAME_SIZE>` setting.
         """
-        return self[SettingCodes.MAX_FRAME_SIZE]
+        # Default RFC value, we can omit it in settings preface!
+        return self.get(SettingCodes.MAX_FRAME_SIZE, 16384)
 
     @max_frame_size.setter
     def max_frame_size(self, value):
@@ -259,7 +259,7 @@ class Settings(MutableMapping):
         The current value of the :data:`ENABLE_CONNECT_PROTOCOL
         <h2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL>` setting.
         """
-        return self[SettingCodes.ENABLE_CONNECT_PROTOCOL]
+        return self.get(SettingCodes.ENABLE_CONNECT_PROTOCOL, 0)
 
     @enable_connect_protocol.setter
     def enable_connect_protocol(self, value):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl Encoder {
 
                 self.inner
                     .encode((header.clone(), value.clone(), header_flags), &mut dst)
-                    .map_err(|_| HPACKError::new_err("operation failed"))?;
+                    .map_err(|e| HPACKError::new_err(format!("encoder failure: {e:?}")))?;
             }
             Ok(())
         })?;
@@ -89,7 +89,7 @@ impl Encoder {
         py.detach(|| {
             self.inner
                 .encode((header.0.clone(), header.1.clone(), flags), &mut dst)
-                .map_err(|_| HPACKError::new_err("operation failed"))
+                .map_err(|e| HPACKError::new_err(format!("encoder failure: {e:?}")))
         })?;
 
         Ok(PyBytes::new(py, dst.as_slice()))
@@ -104,7 +104,7 @@ impl Encoder {
     pub fn set_header_table_size(&mut self, value: u32) -> PyResult<()> {
         self.inner
             .update_max_dynamic_size(value, &mut self.pending_table_size_update)
-            .map_err(|_| HPACKError::new_err("invalid header table size set"))
+            .map_err(|e| HPACKError::new_err(format!("invalid header table size set: {e:?}")))
     }
 }
 
@@ -139,7 +139,7 @@ impl Decoder {
 
                 self.inner
                     .decode_exact(&mut buf, &mut data)
-                    .map_err(|_| HPACKError::new_err("operation failed"))?;
+                    .map_err(|e| HPACKError::new_err(format!("decoder failure: {e:?}")))?;
 
                 if !data.is_empty() {
                     total_mem += data[0].0.len() + data[0].1.len();
@@ -205,6 +205,7 @@ impl Decoder {
         self.inner.set_max_dynamic_size(value);
     }
 
+    // httlib_hpack does not expose the dynamic table current size
     #[getter]
     pub fn get_max_allowed_table_size(&self) -> u32 {
         self.inner.max_dynamic_size()

--- a/tests/test_flow_control_window.py
+++ b/tests/test_flow_control_window.py
@@ -30,7 +30,13 @@ class TestFlowControl(object):
     ]
     server_config = jh2.config.H2Configuration(client_side=False)
 
-    DEFAULT_FLOW_WINDOW = 65535
+    # The default per-stream flow control window, dictated by our local
+    # ``SETTINGS_INITIAL_WINDOW_SIZE`` default.
+    DEFAULT_FLOW_WINDOW = 6291456
+    # Per RFC 7540 §6.9.2 the connection-level flow control window always
+    # starts at 65535 octets regardless of ``INITIAL_WINDOW_SIZE``; the
+    # connection window is therefore the bottleneck on a fresh connection.
+    DEFAULT_CONN_FLOW_WINDOW = 65535
 
     def test_flow_control_initializes_properly(self):
         """
@@ -40,8 +46,8 @@ class TestFlowControl(object):
         c = jh2.connection.H2Connection()
         c.send_headers(1, self.example_request_headers)
 
-        assert c.local_flow_control_window(1) == self.DEFAULT_FLOW_WINDOW
-        assert c.remote_flow_control_window(1) == self.DEFAULT_FLOW_WINDOW
+        assert c.local_flow_control_window(1) == self.DEFAULT_CONN_FLOW_WINDOW
+        assert c.remote_flow_control_window(1) == self.DEFAULT_CONN_FLOW_WINDOW
 
     def test_flow_control_decreases_with_sent_data(self):
         """
@@ -51,7 +57,7 @@ class TestFlowControl(object):
         c.send_headers(1, self.example_request_headers)
         c.send_data(1, b'some data')
 
-        remaining_length = self.DEFAULT_FLOW_WINDOW - len(b'some data')
+        remaining_length = self.DEFAULT_CONN_FLOW_WINDOW - len(b'some data')
         assert (c.local_flow_control_window(1) == remaining_length)
 
     @pytest.mark.parametrize("pad_length", [5, 0])
@@ -67,7 +73,7 @@ class TestFlowControl(object):
 
         c.send_data(1, b'some data', pad_length=pad_length)
         remaining_length = (
-            self.DEFAULT_FLOW_WINDOW - len(b'some data') - pad_length - 1
+            self.DEFAULT_CONN_FLOW_WINDOW - len(b'some data') - pad_length - 1
         )
         assert c.local_flow_control_window(1) == remaining_length
 
@@ -83,7 +89,7 @@ class TestFlowControl(object):
 
         c.receive_data(f1.serialize() + f2.serialize())
 
-        remaining_length = self.DEFAULT_FLOW_WINDOW - len(b'some data')
+        remaining_length = self.DEFAULT_CONN_FLOW_WINDOW - len(b'some data')
         assert (c.remote_flow_control_window(1) == remaining_length)
 
     def test_flow_control_decreases_with_padded_data(self, frame_factory):
@@ -99,7 +105,7 @@ class TestFlowControl(object):
         c.receive_data(f1.serialize() + f2.serialize())
 
         remaining_length = (
-            self.DEFAULT_FLOW_WINDOW - len(b'some data') - 10 - 1
+            self.DEFAULT_CONN_FLOW_WINDOW - len(b'some data') - 10 - 1
         )
         assert (c.remote_flow_control_window(1) == remaining_length)
 
@@ -113,7 +119,7 @@ class TestFlowControl(object):
         c.send_data(1, b'some data')
         c.send_headers(3, self.example_request_headers)
 
-        remaining_length = self.DEFAULT_FLOW_WINDOW - len(b'some data')
+        remaining_length = self.DEFAULT_CONN_FLOW_WINDOW - len(b'some data')
         assert (c.local_flow_control_window(3) == remaining_length)
 
     def test_remote_flow_control_is_limited_by_connection(self, frame_factory):
@@ -131,7 +137,7 @@ class TestFlowControl(object):
         )
         c.receive_data(f1.serialize() + f2.serialize() + f3.serialize())
 
-        remaining_length = self.DEFAULT_FLOW_WINDOW - len(b'some data')
+        remaining_length = self.DEFAULT_CONN_FLOW_WINDOW - len(b'some data')
         assert (c.remote_flow_control_window(3) == remaining_length)
 
     def test_cannot_send_more_data_than_window(self):
@@ -198,7 +204,8 @@ class TestFlowControl(object):
         c = jh2.connection.H2Connection()
         c.send_headers(1, self.example_request_headers)
 
-        assert c.local_flow_control_window(1) == 65535
+        # The conn window is the bottleneck here, per RFC 7540 §6.9.2.
+        assert c.local_flow_control_window(1) == self.DEFAULT_CONN_FLOW_WINDOW
 
         f = frame_factory.build_settings_frame(
             settings={jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 1280}
@@ -215,22 +222,24 @@ class TestFlowControl(object):
         c = jh2.connection.H2Connection()
         c.send_headers(1, self.example_request_headers)
 
-        # Greatly increase the connection flow control window.
+        # Greatly increase the connection flow control window so that the
+        # per-stream window becomes the bottleneck throughout the test.
         f = frame_factory.build_window_update_frame(
-            stream_id=0, increment=128000
+            stream_id=0, increment=12_000_000
         )
         c.receive_data(f.serialize())
 
         # The stream flow control window is the bottleneck here.
-        assert c.local_flow_control_window(1) == 65535
+        assert c.local_flow_control_window(1) == self.DEFAULT_FLOW_WINDOW
 
         f = frame_factory.build_settings_frame(
-            settings={jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 128000}
+            settings={jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE:
+                          8_000_000}
         )
         c.receive_data(f.serialize())
 
-        # The stream window is still the bottleneck, but larger now.
-        assert c.local_flow_control_window(1) == 128000
+        # The stream window grew; conn window is still larger.
+        assert c.local_flow_control_window(1) == 8_000_000
 
     def test_flow_control_settings_blocked_by_conn_window(self, frame_factory):
         """
@@ -240,14 +249,14 @@ class TestFlowControl(object):
         c = jh2.connection.H2Connection()
         c.send_headers(1, self.example_request_headers)
 
-        assert c.local_flow_control_window(1) == 65535
+        assert c.local_flow_control_window(1) == self.DEFAULT_CONN_FLOW_WINDOW
 
         f = frame_factory.build_settings_frame(
-            settings={jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 128000}
+            settings={jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 12000000}
         )
         c.receive_data(f.serialize())
 
-        assert c.local_flow_control_window(1) == 65535
+        assert c.local_flow_control_window(1) == self.DEFAULT_CONN_FLOW_WINDOW
 
     def test_new_streams_have_flow_control_per_settings(self, frame_factory):
         """
@@ -393,7 +402,8 @@ class TestFlowControl(object):
         c = jh2.connection.H2Connection()
         c.send_headers(1, self.example_request_headers)
 
-        assert c.remote_flow_control_window(1) == 65535
+        # The conn window is the bottleneck here, per RFC 7540 §6.9.2.
+        assert c.remote_flow_control_window(1) == self.DEFAULT_CONN_FLOW_WINDOW
 
         c.update_settings({jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 1280})
 
@@ -410,18 +420,21 @@ class TestFlowControl(object):
         c = jh2.connection.H2Connection()
         c.send_headers(1, self.example_request_headers)
 
-        # Increase the connection flow control window greatly.
-        c.increment_flow_control_window(increment=128000)
+        # Increase our conn-level inbound window so the stream window
+        # becomes the bottleneck. ``remote_flow_control_window`` reports
+        # what the peer can send us, which is bounded by our inbound conn
+        # window.
+        c.increment_flow_control_window(increment=12_000_000)
 
-        assert c.remote_flow_control_window(1) == 65535
+        assert c.remote_flow_control_window(1) == self.DEFAULT_FLOW_WINDOW
 
         c.update_settings(
-            {jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 128000}
+            {jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 8_000_000}
         )
         f = frame_factory.build_settings_frame({}, ack=True)
         c.receive_data(f.serialize())
 
-        assert c.remote_flow_control_window(1) == 128000
+        assert c.remote_flow_control_window(1) == 8_000_000
 
     def test_new_streams_have_remote_flow_control(self, frame_factory):
         """
@@ -588,8 +601,9 @@ class TestFlowControl(object):
         c.initiate_connection()
         c.send_headers(1, self.example_request_headers)
 
-        # Go one byte smaller than the limit.
-        increment = 2**31 - 1 - c.outbound_flow_control_window
+        # Pump the stream-1 outbound window all the way up to 2**31 - 1.
+        stream_window = c._get_stream_by_id(1).outbound_flow_control_window
+        increment = 2**31 - 1 - stream_window
 
         f = frame_factory.build_window_update_frame(
             stream_id=1, increment=increment
@@ -641,6 +655,11 @@ class TestFlowControl(object):
     def test_send_update_on_closed_streams(self, frame_factory):
         c = jh2.connection.H2Connection()
         c.initiate_connection()
+        # Bump the connection-level inbound window so that the 40500 bytes
+        # received below stays well clear of the auto-update threshold.
+        c.increment_flow_control_window(
+            increment=self.DEFAULT_FLOW_WINDOW - self.DEFAULT_CONN_FLOW_WINDOW
+        )
         c.send_headers(1, self.example_request_headers)
         c.reset_stream(1)
 
@@ -652,16 +671,13 @@ class TestFlowControl(object):
         events = c.receive_data(f.serialize()*3)
         assert not events
 
+        # 40500 bytes is well below the auto-window-update threshold for the
+        # default ``INITIAL_WINDOW_SIZE`` (6 MiB), so we only expect the
+        # RST_STREAM frames echoed back; no WINDOW_UPDATE is emitted yet.
         expected = frame_factory.build_rst_stream_frame(
             stream_id=1,
             error_code=jh2.errors.ErrorCodes.STREAM_CLOSED,
-        ).serialize() * 2 + frame_factory.build_window_update_frame(
-            stream_id=0,
-            increment=40500,
-        ).serialize() + frame_factory.build_rst_stream_frame(
-            stream_id=1,
-            error_code=jh2.errors.ErrorCodes.STREAM_CLOSED,
-        ).serialize()
+        ).serialize() * 3
         assert c.data_to_send() == expected
 
         f = frame_factory.build_data_frame(b'')
@@ -687,15 +703,26 @@ class TestAutomaticFlowControl(object):
     ]
     server_config = jh2.config.H2Configuration(client_side=False)
 
-    DEFAULT_FLOW_WINDOW = 65535
+    DEFAULT_FLOW_WINDOW = 6291456
+    # Per RFC 7540 §6.9.2 the conn-level flow control window always starts
+    # at 65535 octets regardless of ``INITIAL_WINDOW_SIZE``.
+    DEFAULT_CONN_FLOW_WINDOW = 65535
 
     def _setup_connection_and_send_headers(self, frame_factory):
         """
         Setup a server-side H2Connection and send a headers frame, and then
-        clear the outbound data buffer. Also increase the maximum frame size.
+        clear the outbound data buffer. Also increase the maximum frame size
+        and the connection-level inbound window to match the stream window so
+        that flow-control accounting behaves as the tests below expect.
         """
         c = jh2.connection.H2Connection(config=self.server_config)
         c.initiate_connection()
+        # Bring our conn-level inbound window up to the per-stream default so
+        # the tests can pump up to ``DEFAULT_FLOW_WINDOW`` bytes without
+        # tripping connection-level flow control.
+        c.increment_flow_control_window(
+            increment=self.DEFAULT_FLOW_WINDOW - self.DEFAULT_CONN_FLOW_WINDOW
+        )
         c.receive_data(frame_factory.preamble())
 
         c.update_settings(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,11 +27,10 @@ class TestSettings(object):
         """
         s = jh2.settings.Settings(client=True)
 
-        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 4096
+        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 65536
         assert s[jh2.settings.SettingCodes.ENABLE_PUSH] == 1
-        assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 65535
-        assert s[jh2.settings.SettingCodes.MAX_FRAME_SIZE] == 16384
-        assert s[jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL] == 0
+        assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 6291456
+        assert s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE] == 262144
 
     def test_settings_defaults_server(self):
         """
@@ -39,11 +38,10 @@ class TestSettings(object):
         """
         s = jh2.settings.Settings(client=False)
 
-        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 4096
+        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 65536
         assert s[jh2.settings.SettingCodes.ENABLE_PUSH] == 0
-        assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 65535
-        assert s[jh2.settings.SettingCodes.MAX_FRAME_SIZE] == 16384
-        assert s[jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL] == 0
+        assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 6291456
+        assert s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE] == 262144
 
     @pytest.mark.parametrize('client', [True, False])
     def test_can_set_initial_values(self, client):
@@ -62,7 +60,7 @@ class TestSettings(object):
 
         assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 8080
         assert s[jh2.settings.SettingCodes.ENABLE_PUSH] == bool(client)
-        assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 65535
+        assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 6291456
         assert s[jh2.settings.SettingCodes.MAX_FRAME_SIZE] == 16388
         assert s[jh2.settings.SettingCodes.MAX_CONCURRENT_STREAMS] == 100
         assert s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE] == 2**16
@@ -99,7 +97,7 @@ class TestSettings(object):
         s = jh2.settings.Settings(client=True)
         s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 8000
 
-        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 4096
+        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 65536
 
     def test_acknowledging_values(self):
         """
@@ -112,14 +110,15 @@ class TestSettings(object):
             jh2.settings.SettingCodes.HEADER_TABLE_SIZE: 4000,
             jh2.settings.SettingCodes.ENABLE_PUSH: 0,
             jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 60,
-            jh2.settings.SettingCodes.MAX_FRAME_SIZE: 16385,
-            jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL: 1,
+            jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE: 1024,
         }
         s.update(new_settings)
 
         assert dict(s) == old_settings
         s.acknowledge()
-        assert dict(s) == new_settings
+        # ``new_settings`` only overrode keys already present in defaults
+        expected = {**old_settings, **new_settings}
+        assert dict(s) == expected
 
     def test_acknowledging_returns_the_changed_settings(self):
         """
@@ -140,7 +139,7 @@ class TestSettings(object):
         assert table_size_change.setting == (
             jh2.settings.SettingCodes.HEADER_TABLE_SIZE
         )
-        assert table_size_change.original_value == 4096
+        assert table_size_change.original_value == 65536
         assert table_size_change.new_value == 8000
 
         assert push_change.setting == jh2.settings.SettingCodes.ENABLE_PUSH
@@ -177,16 +176,16 @@ class TestSettings(object):
         Length is related only to the number of keys.
         """
         s = jh2.settings.Settings(client=True)
-        assert len(s) == 5
+        assert len(s) == 4
 
         s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 8000
-        assert len(s) == 5
+        assert len(s) == 4
 
         s.acknowledge()
-        assert len(s) == 5
+        assert len(s) == 4
 
         del s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE]
-        assert len(s) == 4
+        assert len(s) == 3
 
     def test_new_values_work(self):
         """
@@ -219,10 +218,10 @@ class TestSettings(object):
         When acknowledged, unchanged settings remain unchanged.
         """
         s = jh2.settings.Settings(client=True)
-        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 4096
+        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 65536
 
         s.acknowledge()
-        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 4096
+        assert s[jh2.settings.SettingCodes.HEADER_TABLE_SIZE] == 65536
 
     def test_settings_getters(self):
         """
@@ -237,12 +236,19 @@ class TestSettings(object):
         assert s.initial_window_size == (
             s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE]
         )
-        assert s.max_frame_size == s[jh2.settings.SettingCodes.MAX_FRAME_SIZE]
+        # MAX_FRAME_SIZE is no longer part of the default preface; the
+        # property falls back to the RFC 7540 default.
+        assert s.max_frame_size == 16384
+        assert jh2.settings.SettingCodes.MAX_FRAME_SIZE not in s
         assert s.max_concurrent_streams == 2**32 + 1  # A sensible default.
-        assert s.max_header_list_size is None
-        assert s.enable_connect_protocol == s[
-            jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL
-        ]
+        assert s.max_header_list_size == (
+            s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE]
+        )
+        # ENABLE_CONNECT_PROTOCOL is no longer part of the default preface;
+        # the getter returns the RFC default of 0 until the peer advertises
+        # otherwise.
+        assert jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL not in s
+        assert s.enable_connect_protocol == 0
 
     def test_settings_setters(self):
         """
@@ -309,7 +315,7 @@ class TestSettings(object):
             assert (
                 e.value.error_code == jh2.errors.ErrorCodes.FLOW_CONTROL_ERROR
             )
-            assert s.initial_window_size == 65535
+            assert s.initial_window_size == 6291456
 
             with pytest.raises(jh2.exceptions.InvalidSettingsValueError) as e:
                 s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] = val
@@ -318,7 +324,7 @@ class TestSettings(object):
             assert (
                 e.value.error_code == jh2.errors.ErrorCodes.FLOW_CONTROL_ERROR
             )
-            assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 65535
+            assert s[jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE] == 6291456
 
     @given(integers())
     def test_cannot_set_invalid_values_for_max_frame_size(self, val):
@@ -344,14 +350,18 @@ class TestSettings(object):
 
             s.acknowledge()
             assert e.value.error_code == jh2.errors.ErrorCodes.PROTOCOL_ERROR
-            assert s[jh2.settings.SettingCodes.MAX_FRAME_SIZE] == 16384
+            # MAX_FRAME_SIZE is not part of the default preface; the raw key
+            # remains absent after a rejected set.
+            assert jh2.settings.SettingCodes.MAX_FRAME_SIZE not in s
+            assert s.max_frame_size == 16384
 
     @given(integers())
     def test_cannot_set_invalid_values_for_max_header_list_size(self, val):
         """
         SETTINGS_MAX_HEADER_LIST_SIZE only allows non-negative values.
         """
-        s = jh2.settings.Settings()
+        s = jh2.settings.Settings(client=True)
+        default = s.max_header_list_size
 
         if val >= 0:
             s.max_header_list_size = val
@@ -363,16 +373,14 @@ class TestSettings(object):
 
             s.acknowledge()
             assert e.value.error_code == jh2.errors.ErrorCodes.PROTOCOL_ERROR
-            assert s.max_header_list_size is None
+            assert s.max_header_list_size == default
 
             with pytest.raises(jh2.exceptions.InvalidSettingsValueError) as e:
                 s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE] = val
 
             s.acknowledge()
             assert e.value.error_code == jh2.errors.ErrorCodes.PROTOCOL_ERROR
-
-            with pytest.raises(KeyError):
-                s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE]
+            assert s[jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE] == default
 
     @given(integers())
     def test_cannot_set_invalid_values_for_enable_connect_protocol(self, val):
@@ -387,14 +395,16 @@ class TestSettings(object):
 
         s.acknowledge()
         assert e.value.error_code == jh2.errors.ErrorCodes.PROTOCOL_ERROR
-        assert s.enable_connect_protocol == 0
+        # ENABLE_CONNECT_PROTOCOL is not part of the default preface; the key
+        # remains absent after a rejected set.
+        assert jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL not in s
 
         with pytest.raises(jh2.exceptions.InvalidSettingsValueError) as e:
             s[jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL] = val
 
         s.acknowledge()
         assert e.value.error_code == jh2.errors.ErrorCodes.PROTOCOL_ERROR
-        assert s[jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL] == 0
+        assert jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL not in s
 
 
 class TestSettingsEquality(object):


### PR DESCRIPTION
- Fixed RFC conformance (7540 6.9.2) mandates that the connection-level flow-control window always starts at 65535 octets, regardless of what SETTINGS_INITIAL_WINDOW_SIZE advertises.
- Omitted MAX_FRAME_SIZE and ENABLE_CONNECT_PROTOCOL from the default settings preface; both RFC implicit defaults (16384, 0) still apply via property getters.
- Changed default settings: HEADER_TABLE_SIZE -> 4096 to 65536; INITIAL_WINDOW_SIZE = 65535 to 6291456 and MAX_HEADER_LIST_SIZE = unset to 262144.
- Fixed HPACK decoder cap not being initialized from local_settings. HEADER_TABLE_SIZE at construction time; Settings.acknowledge() only emits events for changed values, so defaults never propagated and the decoder stayed at 4096, rejecting legitimate header blocks once HEADER_TABLE_SIZE was raised.
- (rust) Improved HPACK error reporting: replaced generic "operation failed" messages with formatted upstream error variants for diagnosability.